### PR TITLE
Fix wrong scale/offset if u start with the full screen

### DIFF
--- a/push.lua
+++ b/push.lua
@@ -19,9 +19,17 @@ function push:setupScreen(WWIDTH, WHEIGHT, RWIDTH, RHEIGHT, f)
   self._pixelperfect = f.pixelperfect or self._pixelperfect or false
   if f.canvas == nil then f.canvas = true end
 
-  love.window.setMode( self._RWIDTH, self._RHEIGHT, {fullscreen = self._fullscreen, borderless = false, resizable = self._resizable} )
-
+  local windowWidth, windowHeight = love.window.getDesktopDimensions()
+  if self._fullscreen then --save windowed dimensions for later
+    self._WINWIDTH, self._WINHEIGHT = self._RWIDTH, self._RHEIGHT
+  elseif not self._WINWIDTH or not self._WINHEIGHT then
+    self._WINWIDTH, self._WINHEIGHT = windowWidth * .5, windowHeight * .5
+  end
+  self._RWIDTH = self._fullscreen and windowWidth or self._WINWIDTH
+  self._RHEIGHT = self._fullscreen and windowHeight or self._WINHEIGHT
   self:initValues()
+
+  love.window.setMode( self._RWIDTH, self._RHEIGHT, {fullscreen = self._fullscreen, borderless = false, resizable = self._resizable} )
 
   if f.canvas then self:createCanvas() end
 


### PR DESCRIPTION
Look at the picture.
http://imgur.com/a/3ngLc
You see the game screen after calling push's methods.

Before my ugly fix. 
And after my fix. (I just copied a few lines from your switchFullscreen method).

I have illustrated your push methods calls.

So I see the bug when:
 I setup the full screen with "setupScreen" and I do not call "switchFullscreen" method.

I still don't get what initialisation I fixed. Probable the fix could be smaller.

PS I have 2 different monitors with 2 different screen dimensions. 1920x1080 and 1600x900
It is good that you always obtain the current monitor's dimension before the switching.