### PR TITLE
a  changing display N bug sample

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -25,7 +25,7 @@ function love.keypressed(key, scancode, isrepeat)
     examples[example]()
     love.load()
   elseif key == "f" then --activate fullscreen mode
-    push:switchFullscreen() --optional width and height parameters for window mode
+    push:switchFullscreen(640, 480) --optional width and height parameters for window mode
   end
   
 end


### PR DESCRIPTION
If you have >1 displays and call push:switchFullscreen() with parameters
then the constant switching to the full screen mode and back to the windowed mode
resets your current display number.
Basically the window jumps to the 1st Display.