### PR TITLE
Fix 2 bugs in function push:switchFullscreen

### DIFF
--- a/push.lua
+++ b/push.lua
@@ -253,7 +253,7 @@ function push:switchFullscreen(winw, winh)
   
   love.window.setFullscreen(self._fullscreen, "desktop")
   if not self._fullscreen and (winw or winh) then
-    love.window.setMode(self._RWIDTH, self._RHEIGHT) --set window dimensions
+    love.window.updateMode(self._RWIDTH, self._RHEIGHT) --set window dimensions
   end
 end
 

--- a/push.lua
+++ b/push.lua
@@ -252,10 +252,8 @@ function push:switchFullscreen(winw, winh)
   self:initValues()
   
   love.window.setFullscreen(self._fullscreen, "desktop")
-  if not self._fullscreen then
-    _, _, flags = love.window.getMode()
-    flags.fullscreen = false
-    love.window.setMode(self._RWIDTH, self._RHEIGHT, flags) --set window dimensions
+  if not self._fullscreen and (winw or winh) then
+    love.window.setMode(self._RWIDTH, self._RHEIGHT) --set window dimensions
   end
 end
 

--- a/push.lua
+++ b/push.lua
@@ -252,8 +252,10 @@ function push:switchFullscreen(winw, winh)
   self:initValues()
   
   love.window.setFullscreen(self._fullscreen, "desktop")
-  if not self._fullscreen and (winw or winh) then
-    love.window.setMode(self._RWIDTH, self._RHEIGHT) --set window dimensions
+  if not self._fullscreen then
+    _, _, flags = love.window.getMode()
+    flags.fullscreen = false
+    love.window.setMode(self._RWIDTH, self._RHEIGHT, flags) --set window dimensions
   end
 end
 


### PR DESCRIPTION
This proposal looks to solve 2 bugs I found when I pressed f (to go into fullscreen) in the first example. I am using love 11.1 (the latest release).
Bugs:
1) When calling the function without any parameters there is no way to get out of fullscreen mode once its activated. Fixed by editing line 255 and removing the second condition.
2) When calling the function and going into window mode love.window.setMode is called without passing the flags parameter which resets the flags to love2d's defaults instead of keeping the current settings. Fixed by getting the current flags with love.window.getMode, setting fullscreen to false and passing the parameter into love.window.setMode.

Hope this helps! :smile: 