### PR TITLE
Update: love 11.x Stencils

### DIFF
--- a/push.lua
+++ b/push.lua
@@ -84,7 +84,8 @@ function push:addCanvas(params)
     name = params.name,
     private = params.private,
     shader = params.shader,
-    canvas = love.graphics.newCanvas(self._WWIDTH, self._WHEIGHT)
+    canvas = love.graphics.newCanvas(self._WWIDTH, self._WHEIGHT),
+    stencil = params.stencil or self._stencil
   })
 end
 

--- a/push.lua
+++ b/push.lua
@@ -20,7 +20,8 @@ local push = {
     resizable = false,
     pixelperfect = false,
     highdpi = true,
-    canvas = true
+    canvas = true,
+    stencil = true
   }
   
 }
@@ -135,7 +136,7 @@ end
 function push:start()
   if self._canvas then
     love.graphics.push()
-    love.graphics.setCanvas(self.canvases[1].canvas)
+    love.graphics.setCanvas{ self.canvases[1].canvas, stencil = self.canvases[1].stencil }
   else
     love.graphics.translate(self._OFFSET.x, self._OFFSET.y)
     love.graphics.setScissor(self._OFFSET.x, self._OFFSET.y, self._WWIDTH*self._SCALE.x, self._WHEIGHT*self._SCALE.y)

--- a/push.lua
+++ b/push.lua
@@ -137,7 +137,8 @@ end
 function push:start()
   if self._canvas then
     love.graphics.push()
-    love.graphics.setCanvas{ self.canvases[1].canvas, stencil = self.canvases[1].stencil }
+    love.graphics.setCanvas({ self.canvases[1].canvas, stencil = self.canvases[1].stencil })
+
   else
     love.graphics.translate(self._OFFSET.x, self._OFFSET.y)
     love.graphics.setScissor(self._OFFSET.x, self._OFFSET.y, self._WWIDTH*self._SCALE.x, self._WHEIGHT*self._SCALE.y)


### PR DESCRIPTION
#25 

It looks like DPI issue was already resolved, so this PR only adds the needed functionality for the stencil option in love's addCanvas method.

**Stencil Addition:**
I did write this so the user could set the stencil from within the setupScreen method options, added to the canvas object, and lastly passed to the start method. If this variable is not set, Push will simply default to "true", and this is based on the new defaults object setting. This of course allows Love 11 users to update and go back to more important tasks, but if someone wanted to set it they most certainly could, and if they wanted to set it permanently they can change the default's value. 

Because of the intention I left this addition out of the readme as I'm really not sure how many people will actually need the stencil set to ```false```, I haven't worked with stencils near long enough to know the multiple use-cases others have.

**Testing**:
I did test this with every single cs50 game, and did not run into a single error. There were issues with the examples but that seems to be an existing issue with the master branch as well. I guess those will need to be updated. 

**Love 10.x**
Unfortunately I only have one Lua/Love environment setup on OSX, so I lack a working Love 10 binary to test with. It would be ideal for someone with the ability to test this PR with Love 10. I'm hoping that Love 10 will just ignore the stencil variable all together, but if it doesn't it can alway be injected to a custom RenderTargetSetup table when working with Love 11.x. I originally went with this abstraction on canvas creation, but it was quite clunky.
