### PR TITLE
Include love.graphics.reset() disclaimer in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ push:apply(operation)
 ```
 **operation** should be equal to "start" or "end", meaning "before" or "after" your main drawing logic
 
+**Note**: calling `love.graphics.reset()` at any point between `push:start()` and `push:finish()` will result in the rest of your graphics operations executing incorrectly.
+
 Mobile support
 ----------------
 


### PR DESCRIPTION
I spent a while troubleshooting this issue. I'm not positive about the wording but the inability to use love.graphics.reset() between push:start() and push:finish() is useful to include as a disclaimer.