### PR TITLE
Restoring translate offset after rendering

### DIFF
--- a/push.lua
+++ b/push.lua
@@ -200,6 +200,7 @@ local function finish(shader)
 	else
 		love.graphics.pop()
 		love.graphics.setScissor()
+		love.graphics.translate(-offset.x, -offset.y)
 	end
 end
 

--- a/push.lua
+++ b/push.lua
@@ -188,6 +188,7 @@ local function finish(shader)
 			applyShaders(render.canvas, type(shader) == "table" and shader or {shader})
 		end
 		love.graphics.pop()
+		love.graphics.translate(-offset.x, -offset.y)
 
 		-- Clear canvas
 		for i = 1, #canvases do


### PR DESCRIPTION
Hello,

First, I would like to thank you guys for both the initial library and the version `1.0` contributions, which significantly improved an already incredible library.

### The Issue

I'm using push to render my game in a fixed-size canvas, But I'm rendering quite a bit of UI/Editor stuff after calling `push.finish` to render them at native resolution.
I've noticed that push uses `love.graphics.translate` for translating coordination to match render canvas, But we do not revert it to its previous value at the end, hence leaving the push stack with some side effects.

### Solution

I've fixed this by calling `love.graphics.translate` with negative offset values to cancel out the initial translation. It can also be achieved by calling `love.graphics.origin` which is what I did at first, But then I thought in some cases user may want to modify the transform matrix(for example rotating, scaling, etc) in the push stack(between start and finish), or do some translation of themselves and would want to keep it that way after calling finish, So subtracting our offset can be best approach for restoring previous value.